### PR TITLE
Add consultation banner and projects section

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,6 +241,163 @@ function AboutSection() {
   );
 }
 
+function ConsultationBanner() {
+  return (
+    <section
+      className="relative bg-cover bg-center text-white flex flex-col md:flex-row md:items-center justify-between px-8 py-20"
+      style={{
+        backgroundImage:
+          'url(https://images.unsplash.com/photo-1507089947368-19c1da9775ae?auto=format&fit=crop&w=1200&q=60)',
+      }}
+    >
+      <div className="absolute inset-0 bg-gradient-to-r from-black/60 to-transparent"></div>
+      <div className="relative max-w-xl">
+        <h2 className="text-2xl md:text-3xl font-bold mb-2">
+          Free consultation with exceptional quality
+        </h2>
+        <a href="tel:+8411022703" className="underline">
+          Just one call away: +84 1102 2703
+        </a>
+      </div>
+      <div className="relative mt-6 md:mt-0">
+        <button className="border border-white px-5 py-3 rounded-md hover:bg-white hover:text-black">
+          Get your consultation
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function ProjectCard({ image, title, address }) {
+  return (
+    <div className="relative">
+      <img src={image} alt={title} className="w-full h-60 object-cover" />
+      <div className="absolute bottom-0 left-0 right-0 bg-[#2A3B8F] text-white p-4">
+        <div className="font-bold text-sm">{title}</div>
+        <div className="text-xs">{address}</div>
+      </div>
+    </div>
+  );
+}
+
+function SectionFilterTabs({ categories, active, setActive }) {
+  return (
+    <ul className="flex space-x-4 mb-8">
+      {categories.map((c) => (
+        <li
+          key={c}
+          className={`cursor-pointer text-sm ${active === c ? 'text-[#2A3B8F] font-bold border-b-2 border-[#2A3B8F]' : 'text-[#C2C2C2]'}`}
+          onClick={() => setActive(c)}
+        >
+          {c}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function PaginationButton({ direction, onClick }) {
+  const icon = direction === 'prev' ? '\u2190' : '\u2192';
+  return (
+    <button
+      aria-label={direction}
+      onClick={onClick}
+      className="bg-[#1A1A1A] text-white px-6 py-3 rounded-md"
+    >
+      {icon}
+    </button>
+  );
+}
+
+function DotPaginationIndicator({ pageCount, current }) {
+  return (
+    <div className="flex space-x-2">
+      {Array.from({ length: pageCount }).map((_, i) => (
+        <span
+          key={i}
+          className={`w-2 h-2 rounded-full ${i === current ? 'bg-[#2A3B8F]' : 'bg-gray-300'}`}
+        ></span>
+      ))}
+    </div>
+  );
+}
+
+function ProjectsSection() {
+  const data = [
+    {
+      image:
+        'https://images.unsplash.com/photo-1600585153291-4a0294cf01ea?auto=format&fit=crop&w=800&q=60',
+      title: 'Wildstone Infra Hotel',
+      address: '2715 Ash Dr. San Jose, South Dakota',
+      category: 'Commercial',
+    },
+    {
+      image:
+        'https://images.unsplash.com/photo-1568605114967-8130f3a36994?auto=format&fit=crop&w=800&q=60',
+      title: 'Wish Stone Building',
+      address: '2972 Westheimer Rd. Santa Ana, Illinois',
+      category: 'Commercial',
+    },
+    {
+      image:
+        'https://images.unsplash.com/photo-1599423300746-b62533397364?auto=format&fit=crop&w=800&q=60',
+      title: "Mr. Parkinson's House",
+      address: '3517 W. Gray St. Utica, Pennsylvania',
+      category: 'Residential',
+    },
+    {
+      image:
+        'https://images.unsplash.com/photo-1493809842364-78817add7ffb?auto=format&fit=crop&w=800&q=60',
+      title: 'Oregano Height',
+      address: '2464 Royal Ln. Mesa, New Jersey',
+      category: 'Other',
+    },
+  ];
+  const categories = ['All', 'Commercial', 'Residential', 'Other'];
+  const [active, setActive] = useState('All');
+  const [page, setPage] = useState(0);
+  const filtered = data.filter((p) => active === 'All' || p.category === active);
+  const itemsPerPage = 4;
+  const pageCount = Math.ceil(filtered.length / itemsPerPage);
+  const displayed = filtered.slice(
+    page * itemsPerPage,
+    page * itemsPerPage + itemsPerPage
+  );
+
+  const next = () => setPage((p) => (p + 1) % pageCount);
+  const prev = () => setPage((p) => (p - 1 + pageCount) % pageCount);
+
+  React.useEffect(() => {
+    setPage(0);
+  }, [active]);
+
+  return (
+    <section className="my-20 px-8">
+      <h2 className="text-2xl font-bold text-[#1A1A1A] mb-4">Projects</h2>
+      <SectionFilterTabs
+        categories={categories}
+        active={active}
+        setActive={setActive}
+      />
+      <div className="grid gap-6 sm:grid-cols-2">
+        {displayed.map((p) => (
+          <ProjectCard
+            key={p.title}
+            image={p.image}
+            title={p.title}
+            address={p.address}
+          />
+        ))}
+      </div>
+      <div className="flex items-center justify-center mt-8 space-x-4">
+        <PaginationButton direction="prev" onClick={prev} />
+        <DotPaginationIndicator pageCount={pageCount} current={page} />
+        <PaginationButton direction="next" onClick={next} />
+      </div>
+    </section>
+  );
+}
+
       function App() {
         return (
           <div>
@@ -250,6 +407,8 @@ function AboutSection() {
             <AboutSection />
             <ServicesSection />
             <ExperienceSection />
+            <ConsultationBanner />
+            <ProjectsSection />
           </div>
         );
       }


### PR DESCRIPTION
## Summary
- implement a new ConsultationBanner component
- add reusable components for Projects section
- show Projects grid with filtering and pagination controls
- mount new sections in `App`

## Testing
- `node -e "require('fs').readFileSync('index.html','utf8')"`

------
https://chatgpt.com/codex/tasks/task_e_68640b73a75c8321bee381e29b875b67